### PR TITLE
Add optional "private" flag for ephemeral responses

### DIFF
--- a/src/commands/deadlock/History.ts
+++ b/src/commands/deadlock/History.ts
@@ -38,6 +38,12 @@ export default class History extends Command {
           required: true,
           type: ApplicationCommandOptionType.String,
         },
+        {
+          name: "private",
+          description: "Only show result to you",
+          required: false,
+          type: ApplicationCommandOptionType.Boolean,
+        },
       ],
     });
   }
@@ -47,6 +53,7 @@ export default class History extends Command {
     t: TFunction<"translation", undefined>
   ) {
     const player = interaction.options.getString("player");
+    const ephemeral = interaction.options.getBoolean("private", false);
 
     try {
       let _steamId = player;
@@ -137,6 +144,7 @@ ${matchesString.join("\n")}
             .setTimestamp()
             .setFooter({ text: `PlayerID: ${steamProfile.accountId}` }),
         ],
+        flags: ephemeral ? ["Ephemeral"] : [],
       });
     } catch (error) {
       logger.error(error);

--- a/src/commands/deadlock/Match.ts
+++ b/src/commands/deadlock/Match.ts
@@ -54,6 +54,12 @@ export default class Match extends Command {
             },
           ],
         },
+        {
+          name: "private",
+          description: "Only show result to you",
+          required: false,
+          type: ApplicationCommandOptionType.Boolean,
+        },
       ],
     });
   }
@@ -67,10 +73,11 @@ export default class Match extends Command {
       id === "me"
         ? "player_id"
         : interaction.options.getString("type") ?? "match_id";
+    const ephemeral = interaction.options.getBoolean("private", false);
 
     const startTime = performance.now();
 
-    await interaction.deferReply();
+    await interaction.deferReply({flags: ephemeral ? ["Ephemeral"] : []});
 
     try {
       let _matchId: string = id;

--- a/src/commands/deadlock/Performance.ts
+++ b/src/commands/deadlock/Performance.ts
@@ -61,6 +61,12 @@ export default class Performance extends Command {
           required: true,
           type: ApplicationCommandOptionType.String,
         },
+        {
+          name: "private",
+          description: "Only show result to you",
+          required: false,
+          type: ApplicationCommandOptionType.Boolean,
+        },
       ],
     });
   }
@@ -70,9 +76,10 @@ export default class Performance extends Command {
     t: TFunction<"translation", undefined>
   ) {
     const player = interaction.options.getString("player");
+    const ephemeral = interaction.options.getBoolean("private", false);
     const matchHistoryLimit = 100;
 
-    await interaction.deferReply();
+    await interaction.deferReply({flags: ephemeral ? ["Ephemeral"] : []});
 
     try {
       let steamId = player;

--- a/src/commands/deadlock/Stats.ts
+++ b/src/commands/deadlock/Stats.ts
@@ -38,6 +38,12 @@ export default class Stats extends Command {
           required: false,
           type: ApplicationCommandOptionType.String,
         },
+        {
+          name: "private",
+          description: "Only show result to you",
+          required: false,
+          type: ApplicationCommandOptionType.Boolean,
+        },
       ],
     });
   }
@@ -47,6 +53,7 @@ export default class Stats extends Command {
     t: TFunction<"translation", undefined>
   ) {
     const player = interaction.options.getString("player");
+    const ephemeral = interaction.options.getBoolean("private", false);
 
     const HeroSpecificStats: Record<string, string[]> = {
       "Grey Talon": ["max_guided_owl_stacks", "max_spirit_snare_stacks"],
@@ -55,7 +62,7 @@ export default class Stats extends Command {
     };
 
     try {
-      await interaction.deferReply();
+      await interaction.deferReply({flags: ephemeral ? ["Ephemeral"] : []});
       let _steamId = player;
 
       if (player === "me") {

--- a/src/commands/deadlock/Top.ts
+++ b/src/commands/deadlock/Top.ts
@@ -70,6 +70,12 @@ export default class Top extends Command {
             },
           ],
         },
+        {
+          name: "private",
+          description: "Only show result to you",
+          required: false,
+          type: ApplicationCommandOptionType.Boolean,
+        },
       ],
     });
   }
@@ -80,11 +86,12 @@ export default class Top extends Command {
   ) {
     const player = interaction.options.getString("player", true);
     let sortBy = interaction.options.getString("sort_by", false);
+    const ephemeral = interaction.options.getBoolean("private", false);
 
     if (!sortBy) sortBy = "kda";
 
     try {
-      await interaction.deferReply();
+      await interaction.deferReply({flags: ephemeral ? ["Ephemeral"] : []});
       let _steamId = player;
 
       if (player === "me") {


### PR DESCRIPTION
This adds a "private" boolean option to commands, allowing users to choose whether command results are visible only to them. The implementation updates deferReply calls to respect the ephemeral setting.

Fixes #113 