### PR TITLE
added statlocker profile link on performance embed

### DIFF
--- a/src/commands/deadlock/History.ts
+++ b/src/commands/deadlock/History.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
+  escapeMarkdown,
   PermissionsBitField,
 } from "discord.js";
 import Command from "../../base/classes/Command";
@@ -135,7 +136,7 @@ export default class History extends Command {
         "Detailed      ".padEnd(15);
 
       const response = `\`\`\`diff
-${steamProfile.name}'s last ${matches.length} matches:
+${escapeMarkdown(steamProfile.name)}'s last ${matches.length} matches:
 
 ${header}
 ${matchesString.join("\n")}

--- a/src/commands/deadlock/Performance.ts
+++ b/src/commands/deadlock/Performance.ts
@@ -144,9 +144,11 @@ export default class Performance extends Command {
         .setColor("#2f3136")
         .setTitle(`📊 Player Performance Summary`)
         .setDescription(
-          `Recent match performance for **${
+          `Recent match performance for [${
             steamProfile.name || "Player"
-          }** (last ${matches.length} matches)`
+          }](https://statlocker.gg/profile/${steamProfile.accountId}) (last ${
+            matches.length
+          } matches)`
         )
         .setThumbnail(steamProfile.avatarUrl)
         .addFields(

--- a/src/commands/deadlock/Performance.ts
+++ b/src/commands/deadlock/Performance.ts
@@ -5,6 +5,7 @@ import {
   ButtonStyle,
   ChatInputCommandInteraction,
   EmbedBuilder,
+  escapeMarkdown,
   PermissionsBitField,
 } from "discord.js";
 import Command from "../../base/classes/Command";
@@ -144,9 +145,9 @@ export default class Performance extends Command {
         .setColor("#2f3136")
         .setTitle(`📊 Player Performance Summary`)
         .setDescription(
-          `Recent match performance for [${
+          `Recent match performance for [${escapeMarkdown(
             steamProfile.name || "Player"
-          }](https://statlocker.gg/profile/${steamProfile.accountId}) (last ${
+          )}](https://statlocker.gg/profile/${steamProfile.accountId}) (last ${
             matches.length
           } matches)`
         )

--- a/src/commands/deadlock/Stats.ts
+++ b/src/commands/deadlock/Stats.ts
@@ -3,6 +3,7 @@ import {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
   EmbedBuilder,
+  escapeMarkdown,
   PermissionsBitField,
 } from "discord.js";
 import Command from "../../base/classes/Command";
@@ -160,7 +161,7 @@ export default class Stats extends Command {
         .setThumbnail(
           heroName ? hero!.images.minimap_image : steamProfile.avatarUrl
         )
-        .setTitle(`${steamProfile.name}'s stats`)
+        .setTitle(`${escapeMarkdown(steamProfile.name)}'s stats`)
         .setURL(`https://statlocker.gg/profile/${steamProfile.accountId}`)
         .setDescription(description)
         .setTimestamp()

--- a/src/commands/deadlock/Top.ts
+++ b/src/commands/deadlock/Top.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
+  escapeMarkdown,
   PermissionsBitField,
 } from "discord.js";
 import Command from "../../base/classes/Command";
@@ -207,7 +208,9 @@ async function createHeroStatsEmbeds(
 
     if (i === 0) {
       embed.setTitle(
-        `Hero Stats for **${playerName}** sorted by **${sort_by}**`
+        `Hero Stats for **${escapeMarkdown(
+          playerName
+        )}** sorted by **${sort_by}**`
       );
     }
     if (i + chunkSize >= stats.length) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Player names in performance summaries now appear as clickable links to their statlocker.gg profiles.
- **Bug Fixes**
  - Improved display of player names by preventing unintended Markdown formatting in various player stats and history views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->